### PR TITLE
Redirect on Error

### DIFF
--- a/src/Xero.php
+++ b/src/Xero.php
@@ -34,6 +34,11 @@ class Xero extends Server
     protected $scope = [];
 
     /**
+     * @var bool
+     */
+    protected $redirectOnError = false;
+
+    /**
      * {@inheritdoc}
      */
     public function __construct($clientCredentials, SignatureInterface $signature = null)
@@ -86,26 +91,21 @@ class Xero extends Server
     /**
      * @return string
      */
-    protected function buildUrlAuthorizationQueryString(bool $redirectOnError = false)
+    protected function buildUrlAuthorizationQueryString()
     {
-        if (!$this->scope) {
-            if (!$redirectOnError) {
-                return '';
-            }
-            $parameters = '?';
+        if (!$this->scope && !$this->redirectOnError) {
+            return '';
         }
 
-        $parameters = '?scope='.implode(',', $this->scope);
-
-        if ($redirectOnError) {
-            if ($this->scope) {
-                $parameters .= '&';
-            }
-
-            $parameters .= 'redirectOnError=true';
+        if ($this->scope) {
+            $parameters[] = 'scope='.implode(',', $this->scope);
         }
 
-        return $parameters;
+        if ($this->redirectOnError) {
+            $parameters[] = 'redirectOnError=true';
+        }
+
+        return '?'.implode('&', $parameters);
     }
 
     public function urlTokenCredentials()

--- a/src/Xero.php
+++ b/src/Xero.php
@@ -89,6 +89,9 @@ class Xero extends Server
     protected function buildUrlAuthorizationQueryString(bool $redirectOnError = false)
     {
         if (!$this->scope) {
+            if (!$redirectOnError) {
+                return '';
+            }
             $parameters = '?';
         }
 
@@ -98,7 +101,7 @@ class Xero extends Server
             if ($this->scope) {
                 $parameters .= '&';
             }
-            
+
             $parameters .= 'redirectOnError=true';
         }
 

--- a/src/Xero.php
+++ b/src/Xero.php
@@ -86,13 +86,23 @@ class Xero extends Server
     /**
      * @return string
      */
-    protected function buildUrlAuthorizationQueryString()
+    protected function buildUrlAuthorizationQueryString(bool $redirectOnError = false)
     {
         if (!$this->scope) {
-            return '';
+            $parameters = '?';
         }
 
-        return '?scope='.implode(',', $this->scope);
+        $parameters = '?scope='.implode(',', $this->scope);
+
+        if ($redirectOnError) {
+            if ($this->scope) {
+                $parameters .= '&';
+            }
+            
+            $parameters .= 'redirectOnError=true';
+        }
+
+        return $parameters;
     }
 
     public function urlTokenCredentials()

--- a/src/Xero.php
+++ b/src/Xero.php
@@ -68,6 +68,17 @@ class Xero extends Server
     }
 
     /**
+     * Sets the redirect on error parameter used during authorization.
+     *
+     * @param boolean $redirect Boolean to toggle this parameter.
+     * @return void
+     */
+    public function setRedirectOnError(bool $redirect)
+    {
+        $this->redirectOnError = $redirect;
+    }
+
+    /**
      * Creates a Guzzle HTTP client for the given URL.
      *
      * @return GuzzleHttpClient


### PR DESCRIPTION
A project I'm working on requires that the user be redirected back to my application if the user hits cancel in Xero's OAuth.

Luckily this is handled nicely by a request parameter.

[See "Redirect on Error", here](https://developer.xero.com/documentation/auth-and-limits/oauth-callback-domains-explained).

I've added the parameter to the Xero class and defaulted it to false.

Usage is pretty simple:

```php
    $api = new XeroApi();
    $api->setRedirectOnError(true);
```

Now if the Xero part of OAuth fails for any reason (User hits cancel, can't remember password etc.), Xero will redirect us back to the application's callback url.